### PR TITLE
prefectureadd

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_sign_up_params, only: [:create]
+
+  def new
+    super
+  end
+
   def create
     @user = User.new(sign_up_params)
     unless @user.valid?
@@ -11,8 +17,25 @@ class Users::RegistrationsController < Devise::RegistrationsController
     session["devise.regist_data"] = {user: @user.attributes}
     session["devise.regist_data"][:user]["password"] = params[:user][:password]
     @address = @user.build_address
-    render :new_address
+    render :new_destinations
    end
+
+   def new_address
+   end
+
+   def create_address
+    @user = User.new(session["devise.regist_data"]["user"])
+    @address = Address.new(address_params)
+    unless @address.valid?
+      flash.now[:alert] = @address.errors.full_messages
+      render :new_destinations and return
+    end
+    @user.build_address(@address.attributes)
+    @user.save
+    sign_in(:user, @user)
+    redirect_to root_path
+  end
+  
    
    protected
    
@@ -20,4 +43,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
      devise_parameter_sanitizer.permit(:sign_up, keys:
                            [:nickname])
    end
+   def address_params
+    params.require(:address).permit(:prefecture_id)
+  end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,4 +1,5 @@
 class Address < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to_active_hash :prefecture
+  belongs_to_active_hash :prefecture、
+  belongs_to :user, optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_many :diaries
   has_many :comments
+  has_one :address
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -24,4 +24,4 @@
         %br/
         = f.password_field :password_confirmation, {placeholder: "パスワードを入力してください", autocomplete: "off"}
       .actions
-        = f.submit "Sign up"
+        = f.submit "NEXT"

--- a/app/views/devise/registrations/new_destinations.html.haml
+++ b/app/views/devise/registrations/new_destinations.html.haml
@@ -1,0 +1,9 @@
+.contents.row
+  .container
+    %h2 Sign up
+    = form_for(@address, method: :post) do |f|
+      = devise_error_messages!
+      .field
+        = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "選択して下さい", selected: "選択して下さい"}
+      .actions
+        = f.submit "Sign up"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,13 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: 'users/registrations'
   }
+  devise_scope :user do
+    get  'addresses', to: 'users/registrations#new_address'
+    post 'addresses', to: 'users/registrations#create_address'
+  end
+
   root to: 'diaries#index'
+  
   resources :diaries do
     resources :comments, only: :create
     collection do


### PR DESCRIPTION
# What
ユーザーに紐づく形でアドレステーブルを作成しました。
そしてprefecture_idのカラムを追加し、ユーザー新規登録のところで登録できるように
ウィザード形式でユーザー登録できるようにしました。

# Why
これを行うことで、おおよその在住都道府県を登録できるようにし、
次実装予定の天気予報でおおよそのいちの天気ようを写すことができるようになる。